### PR TITLE
Change HEAD to mean --head

### DIFF
--- a/packages/hurl/src/cli/options.rs
+++ b/packages/hurl/src/cli/options.rs
@@ -43,6 +43,7 @@ pub struct CliOptions {
     pub follow_location: bool,
     pub glob_files: Vec<String>,
     pub html_dir: Option<PathBuf>,
+    pub head: bool,
     pub ignore_asserts: bool,
     pub include: bool,
     pub insecure: bool,
@@ -145,6 +146,12 @@ pub fn app(version: &str) -> Command {
                 .action(ArgAction::Append)
                 .number_of_values(1)
                 .help("Specify input files that match the given blob. Multiple glob flags may be used."),
+        )
+        .arg(
+            clap::Arg::new("head")
+                .short('I')
+                .long("head")
+                .help("Show document info only"),
         )
         .arg(
             clap::Arg::new("include")
@@ -335,6 +342,7 @@ pub fn parse_options(matches: &ArgMatches) -> Result<CliOptions, CliError> {
     let fail_fast = !has_flag(matches, "fail_at_end");
     let file_root = get_string(matches, "file_root");
     let follow_location = has_flag(matches, "follow_location");
+    let head = has_flag(matches, "head");
     let glob_files = match_glob_files(matches)?;
     let report_html = get_string(matches, "report_html");
     let html_dir = if let Some(dir) = report_html {
@@ -416,6 +424,7 @@ pub fn parse_options(matches: &ArgMatches) -> Result<CliOptions, CliError> {
         fail_fast,
         file_root,
         follow_location,
+        head,
         glob_files,
         html_dir,
         ignore_asserts,

--- a/packages/hurl/src/http/client.rs
+++ b/packages/hurl/src/http/client.rs
@@ -297,6 +297,12 @@ impl Client {
     /// set method
     ///
     fn set_method(&mut self, method: &Method) {
+        if self.options.head {
+            self.handle.nobody(true).unwrap();
+            self.handle.custom_request("HEAD").unwrap();
+            return
+        }
+
         match method {
             Method::Get => self.handle.custom_request("GET").unwrap(),
             Method::Post => self.handle.custom_request("POST").unwrap(),

--- a/packages/hurl/src/http/options.rs
+++ b/packages/hurl/src/http/options.rs
@@ -34,6 +34,7 @@ pub struct ClientOptions {
     pub user_agent: Option<String>,
     pub compressed: bool,
     pub context_dir: PathBuf,
+    pub head: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -59,6 +60,7 @@ impl Default for ClientOptions {
             user_agent: None,
             compressed: false,
             context_dir: PathBuf::new(),
+            head: false,
         }
     }
 }
@@ -116,6 +118,11 @@ impl ClientOptions {
             arguments.push("--user-agent".to_string());
             arguments.push(format!("'{}'", user_agent));
         }
+
+        if  self.head {
+            arguments.push("--head".to_string())
+        }
+
         arguments
     }
 }
@@ -143,7 +150,8 @@ mod tests {
                 user: Some("user:password".to_string()),
                 user_agent: Some("my-useragent".to_string()),
                 compressed: true,
-                context_dir: PathBuf::new()
+                context_dir: PathBuf::new(),
+                head: true
             }
             .curl_args(),
             [
@@ -164,6 +172,7 @@ mod tests {
                 "'user:password'".to_string(),
                 "--user-agent".to_string(),
                 "'my-useragent'".to_string(),
+                "--head".to_string()
             ]
         );
     }

--- a/packages/hurl/src/http/request_spec_curl_args.rs
+++ b/packages/hurl/src/http/request_spec_curl_args.rs
@@ -122,7 +122,7 @@ impl Method {
                     vec![]
                 }
             }
-            Method::Head => vec!["-X".to_string(), "HEAD".to_string()],
+            Method::Head => vec![],
             Method::Post => {
                 if data {
                     vec![]

--- a/packages/hurl/src/main.rs
+++ b/packages/hurl/src/main.rs
@@ -181,6 +181,7 @@ fn execute(
                 }
                 Some(ref filename) => Path::new(filename),
             };
+            let head = cli_options.head;
             let options = http::ClientOptions {
                 cacert_file,
                 follow_location,
@@ -196,6 +197,7 @@ fn execute(
                 user_agent,
                 compressed,
                 context_dir: context_dir.to_path_buf(),
+                head,
             };
 
             let mut client = http::Client::init(options);


### PR DESCRIPTION
This matches the behaviour suggested by `curl` binary, and ensures HEAD
won't actually try to download the response body.